### PR TITLE
fix: Include latest patched version of DGPF

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.12
-django-globus-portal-framework==0.4.3
+django-globus-portal-framework>=0.4.5
 djangorestframework==3.13.1
 django-cors-headers==3.11.0
 gunicorn==20.1.0


### PR DESCRIPTION
Use the latest patched version of DGPF, which is currently 0.4.5. I believe the older version 0.4.3 had a bug which was the following fixed in 0.4.4: https://github.com/globus/django-globus-portal-framework/commit/20e82311436a64d06facf01b27cb75095ec978b4

Using the latest version will resolve this. 