### PR TITLE
fix: Redirect URI in readme missing trailing slash

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -13,7 +13,7 @@ The Installation below will set default values for the Globus CLIENT_ID and SECR
 If you want to use your own, go to [developers.globus.org](developers.globus.org), create a new app, and ensure the following:
 
 * Native app **is not checked**
-* Redirect URL is set to http://localhost:8000/complete/globus
+* Redirect URL is set to http://localhost:8000/complete/globus/
 
 The Installation process creates a file for storing your credentials called 
 `{{ cookiecutter.project_slug }}/settings/local.py`. It resides next to the 'settings.py' file. When asked for the `globus_client_id` and `globus_secret_key` below, use the ones created from the process above.


### PR DESCRIPTION
This is a small 'gotcha' in using a custom developer app. Django will always append the trailing slash by default when building the redirect URI, and the URIs are similar enough that it isn't obvious why Auth is failing. 

Make sure the Redirect URI in the README contains the trailing slash so folks are less likely to make this mistake.